### PR TITLE
Add availability flag

### DIFF
--- a/creator-plugin-bannergress.user.js
+++ b/creator-plugin-bannergress.user.js
@@ -19,8 +19,7 @@
     /* global oidc angular */
 
     if (window.location.origin !== 'https://missions.ingress.com') {
-        window.creatorPluginAvailable = true;
-        window.dispatchEvent(new Event('creatorPluginAvailable'));
+        document.body.dataset.creatorPluginAvailable = true;
         return;
     }
 

--- a/creator-plugin-bannergress.user.js
+++ b/creator-plugin-bannergress.user.js
@@ -3,7 +3,8 @@
 // @description  Connects Ingress Mission Creator to Bannergress.
 // @author       The Bannergress team
 // @match        https://missions.ingress.com/*
-// @version      1.0
+// @match        https://bannergress.com/*
+// @version      1.1
 // @namespace    https://github.com/bannergress/creator-plugin
 // @updateURL    https://bannergress.com/creator-plugin-bannergress.user.js
 // @downloadURL  https://bannergress.com/creator-plugin-bannergress.user.js
@@ -16,6 +17,12 @@
 
 (async function() {
     /* global oidc angular */
+
+    if (window.location.origin !== 'https://missions.ingress.com') {
+        window.creatorPluginAvailable = true;
+        window.dispatchEvent(new Event('creatorPluginAvailable'));
+        return;
+    }
 
     const api = "https://api.bannergress.com";
     const realm = "bannergress";


### PR DESCRIPTION
Add a flag and an event for the creator plugin availability. This allows to detect the creator plugin presence on bannergress.com.